### PR TITLE
Add getTransactionPresets function for retrieving transaction presets

### DIFF
--- a/src/app/api/finance/actions.ts
+++ b/src/app/api/finance/actions.ts
@@ -8,6 +8,7 @@ import {
   dbGetCategories,
   dbGetCategory,
   dbGetRecentSimilarTransactions,
+  dbGetTransactionPresets,
   dbGetTransactionsByTimeRange,
   dbSetBudget,
 } from "./db";
@@ -80,4 +81,10 @@ export const getCategory = async (categoryId: string) =>
   handle(
     () => withAuth((user) => dbGetCategory(categoryId, user.user.id)),
     "getCategory",
+  );
+
+export const getTransactionPresets = async (sort?: TransactionsSorting) =>
+  handle(
+    () => withAuth((user) => dbGetTransactionPresets(user.user.id, sort)),
+    "getTransactionPresets",
   );

--- a/src/app/api/finance/actions.ts
+++ b/src/app/api/finance/actions.ts
@@ -25,8 +25,8 @@ export const createTransaction = async (
 ) =>
   handle(
     () =>
-      withAuth((user) =>
-        dbCreateTransaction({ ...data, user_id: user.user.id }),
+      withAuth(({ user }) =>
+        dbCreateTransaction({ ...data, user_id: user.id }),
       ),
     "createTransaction",
   );
@@ -34,13 +34,13 @@ export const createTransaction = async (
 export const createCategory = async (data: Omit<AddCategoryInput, "user_id">) =>
   handle(
     () =>
-      withAuth((user) => dbCreateCategory({ ...data, user_id: user.user.id })),
+      withAuth(({ user }) => dbCreateCategory({ ...data, user_id: user.id })),
     "createCategory",
   );
 
 export const setBudget = async (data: SetBudgetInput) => {
   return handle(
-    () => withAuth((user) => dbSetBudget(data, user.user.id)),
+    () => withAuth(({ user }) => dbSetBudget(data, user.id)),
     "setBudget",
   );
 };
@@ -52,15 +52,15 @@ export const getTransactionsByTimeRange = async (
 ) =>
   handle(
     () =>
-      withAuth((user) =>
-        dbGetTransactionsByTimeRange(user.user.id, range, filter, sort),
+      withAuth(({ user }) =>
+        dbGetTransactionsByTimeRange(user.id, range, filter, sort),
       ),
     "getTransactionsByTimeRange",
   );
 
 export const getCategories = async () =>
   handle(
-    () => withAuth((user) => dbGetCategories(user.user.id)),
+    () => withAuth(({ user }) => dbGetCategories(user.id)),
     "getCategories",
   );
 
@@ -70,21 +70,21 @@ export const getRecentSimilarTransactions = async (filter: {
 }) =>
   handle(
     () =>
-      withAuth((user) => {
+      withAuth(({ user }) => {
         const { amount, days = 30 } = filter;
-        return dbGetRecentSimilarTransactions({ amount, days }, user.user.id);
+        return dbGetRecentSimilarTransactions({ amount, days }, user.id);
       }),
     "getRecentSimilarTransactions",
   );
 
 export const getCategory = async (categoryId: string) =>
   handle(
-    () => withAuth((user) => dbGetCategory(categoryId, user.user.id)),
+    () => withAuth(({ user }) => dbGetCategory(categoryId, user.id)),
     "getCategory",
   );
 
 export const getTransactionPresets = async (sort?: TransactionsSorting) =>
   handle(
-    () => withAuth((user) => dbGetTransactionPresets(user.user.id, sort)),
+    () => withAuth(({ user }) => dbGetTransactionPresets(user.id, sort)),
     "getTransactionPresets",
   );

--- a/src/app/api/finance/db.ts
+++ b/src/app/api/finance/db.ts
@@ -128,3 +128,39 @@ export const dbGetCategory = async (categoryId: string, userId: string) => {
     where: and(eq(categories.id, categoryId), eq(categories.user_id, userId)),
   });
 };
+
+export const dbGetTransactionPresets = async (
+  userId: string,
+  sort?: TransactionsSorting,
+) => {
+  return db.query.transactions.findMany({
+    columns: {
+      category_id: false,
+      user_id: false,
+      updated_at: false,
+      is_preset: false,
+    },
+    where: and(
+      eq(transactions.user_id, userId),
+      eq(transactions.is_preset, true),
+    ),
+
+    orderBy: (table, { asc, desc }) =>
+      [
+        sort?.created_at
+          ? sort.created_at === "asc"
+            ? asc(table.created_at)
+            : desc(table.created_at)
+          : undefined,
+      ].filter((elmt) => typeof elmt !== "undefined"),
+
+    with: {
+      category: {
+        columns: {
+          label: true,
+          budget: true,
+        },
+      },
+    },
+  });
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -93,14 +93,15 @@ export const transactionType = pgEnum(
 export const transactions = pgTable("transactions", {
   id: text("id").primaryKey(),
   user_id: text("user_id").notNull(),
-  category_id: text("category_id")
-    .notNull()
-    .references(() => categories.id, { onDelete: "cascade" }),
+  category_id: text("category_id").references(() => categories.id, {
+    onDelete: "cascade",
+  }),
 
   label: varchar({ length: 256 }).notNull(),
   amount: doublePrecision().notNull(),
   type: transactionType("transaction_type").notNull(),
   notes: text("notes"),
+  is_preset: boolean("is_preset").default(false).notNull(),
 
   ...timestamps,
 });


### PR DESCRIPTION
closes #95 
This pull request introduces several changes to the finance API, primarily focusing on adding support for transaction presets. The most important changes include adding a new database query for transaction presets, updating the schema to include a new field, and adding a corresponding API endpoint.

### Enhancements to transaction handling:

* [`src/app/api/finance/actions.ts`](diffhunk://#diff-260fbe41f4f7257f0b40b2ac6e41078ab166248e43cedc83d828118c9c42fe25R11): Added `dbGetTransactionPresets` to the list of imports and created a new `getTransactionPresets` function to handle fetching transaction presets. [[1]](diffhunk://#diff-260fbe41f4f7257f0b40b2ac6e41078ab166248e43cedc83d828118c9c42fe25R11) [[2]](diffhunk://#diff-260fbe41f4f7257f0b40b2ac6e41078ab166248e43cedc83d828118c9c42fe25R85-R90)
* [`src/app/api/finance/db.ts`](diffhunk://#diff-74195402edb16756990a0c66c714be374db2bd3b9bcc42902baf189d7b1a499aR131-R166): Implemented the `dbGetTransactionPresets` function to query transaction presets based on user ID and optional sorting parameters.

### Schema updates:

* [`src/db/schema.ts`](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL96-R104): Modified the `transactions` table schema to include a new `is_preset` boolean field with a default value of `false`.