### PR TITLE
feat: add category filter to recent similar transactions

### DIFF
--- a/src/app/api/finance/actions.ts
+++ b/src/app/api/finance/actions.ts
@@ -67,12 +67,16 @@ export const getCategories = async () =>
 export const getRecentSimilarTransactions = async (filter: {
   amount: number;
   days?: number;
+  categoryId?: string;
 }) =>
   handle(
     () =>
       withAuth(({ user }) => {
-        const { amount, days = 30 } = filter;
-        return dbGetRecentSimilarTransactions({ amount, days }, user.id);
+        const { amount, days = 30, categoryId } = filter;
+        return dbGetRecentSimilarTransactions(
+          { amount, days, categoryId },
+          user.id,
+        );
       }),
     "getRecentSimilarTransactions",
   );

--- a/src/app/api/finance/db.ts
+++ b/src/app/api/finance/db.ts
@@ -81,7 +81,7 @@ export const dbGetRecentSimilarTransactions = async (
   filter: SimilarTransactionsFilter,
   user_id: string,
 ) => {
-  const { amount, days } = filter;
+  const { amount, days, categoryId } = filter;
   const threshold = 0.1 * amount; // 10% threshold for similarity
   const startDate = new Date();
   startDate.setDate(startDate.getDate() - days);
@@ -97,6 +97,7 @@ export const dbGetRecentSimilarTransactions = async (
       gte(transactionsTable.created_at, startDate),
       lte(transactionsTable.amount, amount + threshold),
       gte(transactionsTable.amount, amount - threshold),
+      categoryId ? eq(transactionsTable.category_id, categoryId) : undefined,
     ),
     with: {
       category: {

--- a/src/app/api/finance/types.ts
+++ b/src/app/api/finance/types.ts
@@ -15,6 +15,7 @@ export type Category = InferSelectModel<typeof categoriesTable>;
 export type SimilarTransactionsFilter = {
   amount: number;
   days: number;
+  categoryId?: string;
 };
 
 export type TransactionsFilter = {


### PR DESCRIPTION
closes #118 
This pull request includes changes to the `src/app/api/finance` module to enhance the functionality of retrieving recent similar transactions by adding an optional category filter. The most important changes include updating the filter type, modifying the database query, and adjusting the API action to handle the new filter parameter.

Enhancements to transaction filtering:

* [`src/app/api/finance/types.ts`](diffhunk://#diff-2f4c770210ac715e6ad29b7b88cb6c3a4bb375fc1e9653de5e0df138842e94f8R18): Added `categoryId` as an optional property to the `SimilarTransactionsFilter` type.

Modifications to database query:

* [`src/app/api/finance/db.ts`](diffhunk://#diff-74195402edb16756990a0c66c714be374db2bd3b9bcc42902baf189d7b1a499aL84-R84): Updated the `dbGetRecentSimilarTransactions` function to include `categoryId` in the filter and adjusted the query to handle this new parameter. [[1]](diffhunk://#diff-74195402edb16756990a0c66c714be374db2bd3b9bcc42902baf189d7b1a499aL84-R84) [[2]](diffhunk://#diff-74195402edb16756990a0c66c714be374db2bd3b9bcc42902baf189d7b1a499aR100)

Adjustments to API action:

* [`src/app/api/finance/actions.ts`](diffhunk://#diff-260fbe41f4f7257f0b40b2ac6e41078ab166248e43cedc83d828118c9c42fe25R70-R79): Modified the `getRecentSimilarTransactions` function to pass the `categoryId` parameter to the database query.