### PR TITLE
Enhance type definitions: add ExtractData and ExtractDataItem types f…

### DIFF
--- a/src/app/api/finance/types.ts
+++ b/src/app/api/finance/types.ts
@@ -1,6 +1,11 @@
 import { categoriesTable, transactionsTable } from "@/db/schema";
 import { InferInsertModel, InferSelectModel } from "drizzle-orm";
-import { NoIdAndTimestamp } from "../types";
+import { ExtractData, ExtractDataItem, NoIdAndTimestamp } from "../types";
+import {
+  getCategories,
+  getTransactionPresets,
+  listTransactions,
+} from "./actions";
 
 export type AddTransactionInput = NoIdAndTimestamp<
   InferInsertModel<typeof transactionsTable>
@@ -20,3 +25,27 @@ export type TransactionsSorting = {
   created_at?: "asc" | "desc";
   amount?: "asc" | "desc";
 };
+
+export type TransactionsData = ExtractData<typeof listTransactions>;
+export type TransactionItem = ExtractDataItem<typeof listTransactions>;
+export type TransactionItemWithOptionalDate = Omit<
+  TransactionItem,
+  "created_at"
+> & {
+  created_at?: Date;
+};
+
+export type CategoryData = ExtractData<typeof getCategories>;
+export type CategoryItem = ExtractDataItem<typeof getCategories>;
+export type CategoryItemWithOptionalDates = Omit<
+  CategoryItem,
+  "created_at" | "updated_at"
+> & {
+  created_at?: Date;
+  updated_at?: Date;
+};
+
+export type TransactionPresetsData = ExtractData<typeof getTransactionPresets>;
+export type TransactionPresetItem = ExtractDataItem<
+  typeof getTransactionPresets
+>;

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -12,3 +12,8 @@ export type NoTimestamp<T> = Omit<T, "created_at" | "updated_at">;
 export type NoId<T> = Omit<T, "id">;
 export type NoIdAndTimestamp<T> = Omit<T, "id" | "created_at" | "updated_at">;
 export type NoUser<T> = Omit<T, "user_id">;
+export type ExtractData<T extends (...args: any) => Promise<{ data?: any }>> =
+  NonNullable<Awaited<ReturnType<T>>["data"]>;
+export type ExtractDataItem<
+  T extends (...args: any) => Promise<{ data?: any }>,
+> = ExtractData<T> extends Array<infer U> ? U : never;


### PR DESCRIPTION
…or improved data handling
closes #141 
This pull request includes several changes to the type definitions in the `src/app/api/finance/types.ts` and `src/app/api/types.ts` files. The primary goal is to introduce new utility types for extracting data and data items from asynchronous functions, and to define new types for transaction and category data.

New utility types and type definitions:

* [`src/app/api/types.ts`](diffhunk://#diff-2d46667a940b14d0081a63b0d244851e90db853e72f0e5921649c23507c20940R15-R19): Added `ExtractData` and `ExtractDataItem` utility types to extract data and data items from asynchronous functions.

New types for transactions and categories:

* [`src/app/api/finance/types.ts`](diffhunk://#diff-2f4c770210ac715e6ad29b7b88cb6c3a4bb375fc1e9653de5e0df138842e94f8R28-R51): Added `TransactionsData`, `TransactionItem`, `TransactionItemWithOptionalDate`, `CategoryData`, `CategoryItem`, `CategoryItemWithOptionalDates`, `TransactionPresetsData`, and `TransactionPresetItem` types. These types use the new `ExtractData` and `ExtractDataItem` utility types.