### PR TITLE
Add getTransactionsCount function and related database query

### DIFF
--- a/src/app/api/finance/actions.ts
+++ b/src/app/api/finance/actions.ts
@@ -10,6 +10,7 @@ import {
   dbGetCategories,
   dbGetCategory,
   dbGetTransactionPresets,
+  dbGetTransactionsCount,
   dbListTransactions,
   dbUpdateCategory,
   dbUpdateTransaction,
@@ -75,6 +76,13 @@ export const getTransactionPresets = async (sort?: TransactionsSorting) =>
     () => withAuth(({ user }) => dbGetTransactionPresets(user.id, sort)),
     "getTransactionPresets",
   );
+
+export const getTransactionsCount = async (filter: TransactionsFilter) => {
+  return handle(
+    () => withAuth(({ user }) => dbGetTransactionsCount(user.id, filter)),
+    "getTransactionsCount",
+  );
+};
 
 export const createCategory = async (data: Omit<AddCategoryInput, "user_id">) =>
   handle(

--- a/src/app/api/finance/db.ts
+++ b/src/app/api/finance/db.ts
@@ -1,7 +1,7 @@
 import { db } from "@/db";
 import { categoriesTable, transactionsTable } from "@/db/schema";
 import { generateId } from "@/lib/utils";
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, count, eq, gte, lte } from "drizzle-orm";
 import { NoUser, TimeRange } from "../types";
 import {
   AddCategoryInput,
@@ -141,6 +141,23 @@ export const dbGetTransactionPresets = async (
       },
     },
   });
+};
+
+export const dbGetTransactionsCount = async (
+  userId: string,
+  filter: TransactionsFilter,
+) => {
+  const result = await db
+    .select({ count: count() })
+    .from(transactionsTable)
+    .where(
+      and(
+        eq(transactionsTable.user_id, userId),
+        filter?.type ? eq(transactionsTable.type, filter.type) : undefined,
+      ),
+    );
+
+  return result[0]?.count ?? 0;
 };
 
 export const dbCreateCategory = async (data: AddCategoryInput) => {

--- a/src/app/api/finance/types.ts
+++ b/src/app/api/finance/types.ts
@@ -1,6 +1,6 @@
 import { categoriesTable, transactionsTable } from "@/db/schema";
 import { InferInsertModel, InferSelectModel } from "drizzle-orm";
-import { ExtractData, ExtractDataItem, NoIdAndTimestamp } from "../types";
+import { APIResponse, ExtractData, ExtractDataItem, NoIdAndTimestamp } from "../types";
 import {
   getCategories,
   getTransactionPresets,
@@ -49,3 +49,4 @@ export type TransactionPresetsData = ExtractData<typeof getTransactionPresets>;
 export type TransactionPresetItem = ExtractDataItem<
   typeof getTransactionPresets
 >;
+type GetTransactionListResponse = APIResponse<ExtractData<typeof listTransactions>>;

--- a/src/app/api/journal/actions.ts
+++ b/src/app/api/journal/actions.ts
@@ -23,9 +23,7 @@ import {
   ListJournalSort,
 } from "./types";
 
-export const createJournal = async (
-  data: CreateJournalInput,
-) =>
+export const createJournal = async (data: CreateJournalInput) =>
   handle(
     () =>
       withAuth(async ({ user }) => {


### PR DESCRIPTION
closes #150 
This pull request includes several updates to the finance API, including the addition of a new function to get the count of transactions, and some minor refactoring in the journal actions. The most important changes are outlined below:

### Finance API Updates:

* Added `dbGetTransactionsCount` to the list of imported functions in `src/app/api/finance/actions.ts`.
* Implemented `getTransactionsCount` function in `src/app/api/finance/actions.ts` to handle fetching the count of transactions based on a filter.
* Added `dbGetTransactionsCount` function to `src/app/api/finance/db.ts` to query the database for the count of transactions matching the filter criteria.
* Imported the `count` function from `drizzle-orm` in `src/app/api/finance/db.ts` to support the new database query.
* Added a type definition for `GetTransactionListResponse` in `src/app/api/finance/types.ts` to standardize the API response format.