### PR TITLE
Implement caching and revalidation for transaction and journal operat…

### DIFF
--- a/src/actions/journal/db.ts
+++ b/src/actions/journal/db.ts
@@ -36,7 +36,7 @@ export const dbCreateJournal = async (
 
 export const dbGetJournal = async (journalId: string, userId: string) => {
   "use cache";
-  cacheTag("journals", `journal-${ journalId }`);
+  cacheTag("journals", `journal-${journalId}`);
   return db.query.journalingTable.findFirst({
     where: and(
       eq(journalingTable.id, journalId),
@@ -164,8 +164,6 @@ export const dbUpdateJournal = async (
   return data;
 };
 
-
-
 export const dbCreateJournalTag = async (
   user_id: string,
   data: CreateJournalTagInput,
@@ -185,6 +183,7 @@ export const dbDeleteJournalTag = async (user_id: string, tagId: string) => {
   await db
     .delete(tagsTable)
     .where(and(eq(tagsTable.id, tagId), eq(tagsTable.user_id, user_id)));
+  revalidateTag("journals");
   return true;
 };
 
@@ -197,6 +196,7 @@ export const dbUpdateJournalTag = async (
     .update(tagsTable)
     .set({ ...data, updated_at: new Date() })
     .where(and(eq(tagsTable.id, tagId), eq(tagsTable.user_id, user_id)));
+  revalidateTag("journals");
   return data;
 };
 
@@ -208,6 +208,7 @@ export const dbAttachTagToJournal = async (
   await db
     .insert(journalsToTags)
     .values({ journal_id: journalId, tag_id: tagId, user_id: userId });
+  revalidateTag("journals");
   return true;
 };
 
@@ -225,5 +226,6 @@ export const dbDetachTagFromJournal = async (
         eq(journalsToTags.tag_id, tagId),
       ),
     );
+  revalidateTag("journals");
   return true;
 };


### PR DESCRIPTION
…ions
closes #84 
This pull request introduces caching and cache invalidation mechanisms for database operations across the `finance` and `journal` modules. The changes include adding `revalidateTag` calls to invalidate cache after write operations and introducing `"use cache"` and `cacheTag` directives for read operations to optimize performance.

### Caching and Cache Invalidation for Finance Module

* Added `revalidateTag("transactions")` after `dbCreateTransaction`, `dbUpdateTransaction`, and `dbDeleteTransaction` to invalidate the cache for transactions after write operations. (`src/actions/finance/db.ts`: [[1]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R24) [[2]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R42) [[3]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R58)
* Added `"use cache"` and `cacheTag("transactions")` for `dbListTransactions`, `dbGetTransactionPresets`, and `dbGetTransactionsCount` to enable caching for transaction-related read operations. (`src/actions/finance/db.ts`: [[1]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R77-R78) [[2]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R132-R133) [[3]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R173-R174)
* Added `revalidateTag("categories")` after `dbCreateCategory`, `dbUpdateCategory`, and `dbDeleteCategory` to invalidate the cache for categories after write operations. (`src/actions/finance/db.ts`: [[1]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R199-R205) [[2]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R229-R235) [[3]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R253)
* Added `"use cache"` and `cacheTag("categories")` for `dbGetCategories` and `dbGetCategory` to enable caching for category-related read operations. (`src/actions/finance/db.ts`: [[1]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R199-R205) [[2]](diffhunk://#diff-08534d0891d84d90f276af9824a5c618bd25170cb37d07d4a6b1e7aa5e725a92R229-R235)

### Caching and Cache Invalidation for Journal Module

* Added `revalidateTag("journals")` after `dbDeleteJournalTag`, `dbUpdateJournalTag`, `dbAttachTagToJournal`, and `dbDetachTagFromJournal` to invalidate the cache for journals after write operations. (`src/actions/journal/db.ts`: [[1]](diffhunk://#diff-3fcba61bca89962b2e7ccea017fa22d9f2563b9d54737fe2648baf19b8002bd7R186) [[2]](diffhunk://#diff-3fcba61bca89962b2e7ccea017fa22d9f2563b9d54737fe2648baf19b8002bd7R199) [[3]](diffhunk://#diff-3fcba61bca89962b2e7ccea017fa22d9f2563b9d54737fe2648baf19b8002bd7R211) [[4]](diffhunk://#diff-3fcba61bca89962b2e7ccea017fa22d9f2563b9d54737fe2648baf19b8002bd7R229)

These changes ensure that the cache remains consistent with the database while improving the performance of read operations by leveraging caching.